### PR TITLE
Add server api

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # joppy
 
-Python interface for the [Joplin data API](https://joplinapp.org/api/references/rest_api/).
+Python interface for the [Joplin data API](https://joplinapp.org/api/references/rest_api/) (client) and the Joplin server API.
 
 [![build](https://github.com/marph91/joppy/actions/workflows/build.yml/badge.svg)](https://github.com/marph91/joppy/actions/workflows/build.yml)
 [![lint](https://github.com/marph91/joppy/actions/workflows/lint.yml/badge.svg)](https://github.com/marph91/joppy/actions/workflows/lint.yml)
@@ -40,6 +40,8 @@ pip install .
 For details, consult the [implementation](joppy/api.py), [joplin documentation](https://joplinapp.org/api/references/rest_api/) or [create an issue](https://github.com/marph91/joppy/issues).
 
 ## :bulb: Example snippets
+
+### Client API
 
 Start joplin and [get your API token](https://joplinapp.org/api/references/rest_api/#authorisation). Click to expand the examples.
 
@@ -218,7 +220,24 @@ for resource in api.get_all_resources():
 
 </details>
 
-For more usage examples, check the example scripts or [tests](test/test_api.py).
+For more usage examples, check the example scripts or [tests](test/test_client_api.py).
+
+### Server API
+
+The server API should work similarly to the client API in most cases. **Be aware that the server API is experimental and may break at any time. Make sure you have a backup and know how to restore it.**
+
+```python
+from joppy.server_api import ServerApi
+
+# Create a new Api instance.
+api = ServerApi(user="admin@localhost", password="admin", url="http://localhost:22300")
+
+# Add a notebook.
+notebook_id = api.add_notebook(title="My first notebook")
+
+# Add a note in the previously created notebook.
+note_id = api.add_note(title="My first note", body="With some content", parent_id=notebook_id)
+```
 
 ## :newspaper: Examples
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Python interface for the [Joplin data API](https://joplinapp.org/api/references/
 |     | Client API Wrapper | Server API Wrapper |
 | --- | --- | --- |
 | **Supported** | All functions from the [data API](https://joplinapp.org/help/api/references/rest_api/) | Some reverse engineered functions with a similar interface like the client API wrapper. See the example below and the source code for details. |
-| **Not Supported** | -  | - Encryption  <br>- Some functions that were either to complex or I didn't see a use for automation. |
+| **Not Supported** | -  | - Encryption <br>- Some functions that were either to complex or I didn't see a use for automation. |
 
 ## :computer: Installation
 
@@ -233,7 +233,7 @@ For more usage examples, check the example scripts or [tests](test/test_client_a
 
 ### Server API
 
-The server API should work similarly to the client API in most cases. **Be aware that the server API is experimental and may break at any time. Make sure you have a backup and know how to restore it.**
+The server API should work similarly to the client API in most cases. **Be aware that the server API is experimental and may break at any time. I can't provide any help at sync issues or lost data. Make sure you have a backup and know how to restore it.**
 
 ```python
 from joppy.server_api import ServerApi

--- a/README.md
+++ b/README.md
@@ -241,11 +241,14 @@ from joppy.server_api import ServerApi
 # Create a new Api instance.
 api = ServerApi(user="admin@localhost", password="admin", url="http://localhost:22300")
 
-# Add a notebook.
-notebook_id = api.add_notebook(title="My first notebook")
+# Acquire a lock.
+with api.sync_lock():
 
-# Add a note in the previously created notebook.
-note_id = api.add_note(title="My first note", body="With some content", parent_id=notebook_id)
+    # Add a notebook.
+    notebook_id = api.add_notebook(title="My first notebook")
+
+    # Add a note in the previously created notebook.
+    note_id = api.add_note(title="My first note", body="With some content", parent_id=notebook_id)
 ```
 
 ## :newspaper: Examples

--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ Python interface for the [Joplin data API](https://joplinapp.org/api/references/
 [![https://img.shields.io/badge/Joplin-3.0.15-blueviolet](https://img.shields.io/badge/Joplin-3.0.15-blueviolet)](https://github.com/laurent22/joplin)
 [![Python version](https://img.shields.io/pypi/pyversions/joppy.svg)](https://pypi.python.org/pypi/joppy/)
 
+## Features
+
+|     | Client API Wrapper | Server API Wrapper |
+| --- | --- | --- |
+| **Supported** | All functions from the [data API](https://joplinapp.org/help/api/references/rest_api/) | Some reverse engineered functions with a similar interface like the client API wrapper. See the example below and the source code for details. |
+| **Not Supported** | -  | - Encryption  <br>- Some functions that were either to complex or I didn't see a use for automation. |
+
 ## :computer: Installation
 
 From pypi:
@@ -27,6 +34,8 @@ pip install .
 ```
 
 ## :wrench: Usage
+
+Please backup your data before use!
 
 ### General function description
 

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ Start joplin and [get your API token](https://joplinapp.org/api/references/rest_
 <summary>Get all notes</summary>
 
 ```python name=get_all_notes
-from joppy.api import Api
+from joppy.client_api import ClientApi
 
 # Create a new Api instance.
-api = Api(token=YOUR_TOKEN)
+api = ClientApi(token=YOUR_TOKEN)
 
 # Get all notes. Note that this method calls get_notes() multiple times to assemble the unpaginated result.
 notes = api.get_all_notes()
@@ -62,11 +62,11 @@ notes = api.get_all_notes()
 <summary>Add a tag to a note</summary>
   
 ```python name=add_tag_to_note
-from joppy.api import Api
+from joppy.client_api import ClientApi
 
 # Create a new Api instance.
 
-api = Api(token=YOUR_TOKEN)
+api = ClientApi(token=YOUR_TOKEN)
 
 # Add a notebook.
 
@@ -92,11 +92,11 @@ api.add_tag_to_note(tag_id=tag_id, note_id=note_id)
 <summary>Add a resource to a note</summary>
 
 ```python name=add_resource_to_note
-from joppy.api import Api
+from joppy.client_api import ClientApi
 from joppy import tools
 
 # Create a new Api instance.
-api = Api(token=YOUR_TOKEN)
+api = ClientApi(token=YOUR_TOKEN)
 
 # Add a notebook.
 notebook_id = api.add_notebook(title="My first notebook")
@@ -124,10 +124,10 @@ Inspired by <https://discourse.joplinapp.org/t/bulk-tag-delete-python-script/549
 ```python name=remove_tags
 import re
 
-from joppy.api import Api
+from joppy.client_api import ClientApi
 
 # Create a new Api instance.
-api = Api(token=YOUR_TOKEN)
+api = ClientApi(token=YOUR_TOKEN)
 
 # Iterate through all tags.
 for tag in api.get_all_tags():
@@ -145,10 +145,10 @@ for tag in api.get_all_tags():
 Reference: <https://discourse.joplinapp.org/t/prune-empty-tags-from-web-clipper/36194>
 
 ```python name=remove_unused_tags
-from joppy.api import Api
+from joppy.client_api import ClientApi
 
 # Create a new Api instance.
-api = Api(token=YOUR_TOKEN)
+api = ClientApi(token=YOUR_TOKEN)
 
 for tag in api.get_all_tags():
     notes_for_tag = api.get_all_notes(tag_id=tag.id)
@@ -167,10 +167,10 @@ Reference: <https://www.reddit.com/r/joplinapp/comments/pozric/batch_remove_spac
 ```python name=remove_spaces_from_tags
 import re
 
-from joppy.api import Api
+from joppy.client_api import ClientApi
 
 # Create a new Api instance.
-api = Api(token=YOUR_TOKEN)
+api = ClientApi(token=YOUR_TOKEN)
 
 # Define the conversion function.
 def to_camel_case(name: str) -> str:
@@ -193,10 +193,10 @@ Note: The note history is not considered. See: <https://discourse.joplinapp.org/
 ```python name=remove_orphaned_resources
 import re
 
-from joppy.api import Api
+from joppy.client_api import ClientApi
 
 # Create a new Api instance.
-api = Api(token=YOUR_TOKEN)
+api = ClientApi(token=YOUR_TOKEN)
 
 # Getting the referenced resource directly doesn't work:
 # https://github.com/laurent22/joplin/issues/4535
@@ -257,6 +257,11 @@ It's possible to configure the test run via some environment variables:
 - `API_TOKEN`: Set this variable if there is already a joplin instance running. **Don't use your default joplin profile!** By default, a joplin instance is started inside xvfb. This takes some time, but works for CI.
 
 ## :book: Changelog
+
+### Master
+
+- Rename the client API. It should be used by `from joppy.client_api import ClientApi` instead of `from joppy.client_api import ClientApi` now.
+- Add support for the server API. It should be used by `from joppy.server_api import ServerApi`.
 
 ### 0.2.3
 

--- a/joppy/client_api.py
+++ b/joppy/client_api.py
@@ -372,7 +372,7 @@ class Tag(ApiBase):
         self.put(f"/tags/{id_}", data=data)
 
 
-class Api(Event, Note, Notebook, Ping, Resource, Revision, Search, Tag):
+class ClientApi(Event, Note, Notebook, Ping, Resource, Revision, Search, Tag):
     """
     Collects all basic API functions and contains a few more useful methods.
     This should be the only class accessed from the users.

--- a/joppy/client_api.py
+++ b/joppy/client_api.py
@@ -6,7 +6,6 @@ import logging
 import time
 from typing import (
     Any,
-    Callable,
     cast,
     Dict,
     List,
@@ -18,6 +17,7 @@ import urllib.parse
 import requests
 
 import joppy.data_types as dt
+from joppy import tools
 
 
 # Use a global session object for better performance.
@@ -33,12 +33,12 @@ LOGGER = logging.getLogger("joppy")
 
 
 ##############################################################################
-# Base wrapper that manages the requests to the REST API.
+# Base wrapper that manages the requests to the client REST API.
 ##############################################################################
 
 
 class ApiBase:
-    """Contains the basic requests of the REST API."""
+    """Contains the basic requests of the client REST API."""
 
     def __init__(self, token: str, url: str = "http://localhost:41184") -> None:
         self.url = url
@@ -429,47 +429,32 @@ class ClientApi(Event, Note, Notebook, Ping, Resource, Revision, Search, Tag):
             assert tag.id is not None
             self.delete_tag(tag.id)
 
-    @staticmethod
-    def _unpaginate(
-        func: Callable[..., dt.DataList[dt.T]], **query: dt.JoplinTypes
-    ) -> List[dt.T]:
-        """Calls an Joplin endpoint until it's response doesn't contain more data."""
-        response = func(**query)
-        items = response.items
-        page = 1  # pages are one based
-        while response.has_more:
-            page += 1
-            query["page"] = page
-            response = func(**query)
-            items.extend(response.items)
-        return items
-
     def get_all_events(self, **query: dt.JoplinTypes) -> List[dt.EventData]:
         """Get all events, unpaginated."""
-        return self._unpaginate(self.get_events, **query)
+        return tools._unpaginate(self.get_events, **query)
 
     def get_all_notes(self, **query: dt.JoplinTypes) -> List[dt.NoteData]:
         """Get all notes, unpaginated."""
-        return self._unpaginate(self.get_notes, **query)
+        return tools._unpaginate(self.get_notes, **query)
 
     def get_all_notebooks(self, **query: dt.JoplinTypes) -> List[dt.NotebookData]:
         """Get all notebooks, unpaginated."""
-        return self._unpaginate(self.get_notebooks, **query)
+        return tools._unpaginate(self.get_notebooks, **query)
 
     def get_all_resources(self, **query: dt.JoplinTypes) -> List[dt.ResourceData]:
         """Get all resources, unpaginated."""
-        return self._unpaginate(self.get_resources, **query)
+        return tools._unpaginate(self.get_resources, **query)
 
     def get_all_revisions(self, **query: dt.JoplinTypes) -> List[dt.RevisionData]:
         """Get all revisions, unpaginated."""
-        return self._unpaginate(self.get_revisions, **query)
+        return tools._unpaginate(self.get_revisions, **query)
 
     def get_all_tags(self, **query: dt.JoplinTypes) -> List[dt.TagData]:
         """Get all tags, unpaginated."""
-        return self._unpaginate(self.get_tags, **query)
+        return tools._unpaginate(self.get_tags, **query)
 
     def search_all(
         self, **query: dt.JoplinTypes
     ) -> List[Union[dt.NoteData, dt.NotebookData, dt.ResourceData, dt.TagData]]:
         """Issue a search and get all results, unpaginated."""
-        return self._unpaginate(self.search, **query)  # type: ignore
+        return tools._unpaginate(self.search, **query)  # type: ignore

--- a/joppy/data_types.py
+++ b/joppy/data_types.py
@@ -56,18 +56,21 @@ class MarkupLanguage(enum.IntEnum):
 
 
 def is_id_valid(id_: str) -> bool:
-    """
-    Check whether a string is a valid id. See:
-    https://joplinapp.org/api/references/rest_api/#creating-a-note-with-a-specific-id.
-    """
-    if len(id_) != 32:
-        return False
-    # https://stackoverflow.com/a/11592279/7410886
-    try:
-        int(id_, 16)
-    except ValueError:
-        return False
-    return True
+    """Check whether a string is a valid id."""
+    if len(id_) == 32:
+        # client ID
+        # https://joplinapp.org/api/references/rest_api/#creating-a-note-with-a-specific-id
+        # https://stackoverflow.com/a/11592279/7410886
+        try:
+            int(id_, 16)
+            return True
+        except ValueError:
+            return False
+    if len(id_) == 22:
+        # server ID
+        # https://joplinapp.org/help/dev/spec/server_items/
+        return True
+    return False
 
 
 @dataclass
@@ -485,13 +488,49 @@ class EventData(BaseData):
         return {"id", "item_type", "item_id", "type", "created_time"}
 
 
+@dataclass
+class UserData(BaseData):
+    """
+    https://joplinapp.org/help/dev/spec/server_user_status/
+    https://github.com/laurent22/joplin/blob/b617a846964ea49be2ffefd31439e911ad84ed8c/packages/server/src/models/UserModel.ts#L117
+    """
+
+    id: Optional[str] = None
+    email: Optional[str] = None
+    password: Optional[str] = None
+    is_admin: Optional[bool] = None
+    full_name: Optional[str] = None
+    created_time: Optional[datetime] = None
+    updated_time: Optional[datetime] = None
+    email_confirmed: Optional[bool] = None
+    must_set_password: Optional[bool] = None
+    account_type: Optional[int] = None  # TODO: enum
+    can_upload: Optional[bool] = None
+    max_item_size: Optional[int] = None
+    max_total_item_size: Optional[int] = None
+    total_item_size: Optional[int] = None
+    can_share_folder: Optional[bool] = None
+    can_share_note: Optional[bool] = None
+    can_receive_folder: Optional[bool] = None
+    enabled: Optional[bool] = None
+    disabled_time: Optional[datetime] = None
+
+
 AnyData = Union[
     EventData, NoteData, NotebookData, NoteTagData, ResourceData, RevisionData, TagData
 ]
 
 
 T = TypeVar(
-    "T", EventData, NoteData, NotebookData, ResourceData, RevisionData, TagData, str
+    "T",
+    EventData,
+    NoteData,
+    NotebookData,
+    ResourceData,
+    RevisionData,
+    TagData,
+    UserData,
+    str,
 )
 
 

--- a/joppy/data_types.py
+++ b/joppy/data_types.py
@@ -206,35 +206,34 @@ class NoteData(BaseData):
         if self.body is not None:
             lines.extend([self.body, ""])
         for field_ in fields(self):
-            match field_.name:
-                case "id":
-                    # ID is always required
-                    if self.id is None:
-                        self.id = uuid.uuid4().hex
-                    lines.append(f"{field_.name}: {self.id}")
-                case "markup_language":
-                    # required to get an editable note
-                    if self.markup_language is None:
-                        self.markup_language = MarkupLanguage.MARKDOWN
-                    lines.append(f"{field_.name}: {self.markup_language}")
-                case "source_application":
-                    if self.source_application is None:
-                        self.source_application = "joppy"
-                    lines.append(f"{field_.name}: {self.source_application}")
-                case "title" | "body":
-                    pass  # handled before
-                case "type_":
-                    self.item_type = ItemType.NOTE
-                    lines.append(f"{field_.name}: {self.item_type}")
-                case "updated_time":
-                    # required, even if empty
-                    value_raw = getattr(self, field_.name)
-                    value = "" if value_raw is None else value_raw
-                    lines.append(f"{field_.name}: {value}")
-                case _:
-                    value_raw = getattr(self, field_.name)
-                    if value_raw is not None:
-                        lines.append(f"{field_.name}: {value_raw}")
+            if field_.name == "id":
+                # ID is always required
+                if self.id is None:
+                    self.id = uuid.uuid4().hex
+                lines.append(f"{field_.name}: {self.id}")
+            elif field_.name == "markup_language":
+                # required to get an editable note
+                if self.markup_language is None:
+                    self.markup_language = MarkupLanguage.MARKDOWN
+                lines.append(f"{field_.name}: {self.markup_language}")
+            elif field_.name == "source_application":
+                if self.source_application is None:
+                    self.source_application = "joppy"
+                lines.append(f"{field_.name}: {self.source_application}")
+            elif field_.name in ("title", "body"):
+                pass  # handled before
+            elif field_.name == "type_":
+                self.item_type = ItemType.NOTE
+                lines.append(f"{field_.name}: {self.item_type}")
+            elif field_.name == "updated_time":
+                # required, even if empty
+                value_raw = getattr(self, field_.name)
+                value = "" if value_raw is None else value_raw
+                lines.append(f"{field_.name}: {value}")
+            else:
+                value_raw = getattr(self, field_.name)
+                if value_raw is not None:
+                    lines.append(f"{field_.name}: {value_raw}")
         return "\n".join(lines)
 
 
@@ -263,26 +262,25 @@ class NotebookData(BaseData):
         if self.title is not None:
             lines.extend([self.title, ""])
         for field_ in fields(self):
-            match field_.name:
-                case "id":
-                    # ID is always required
-                    if self.id is None:
-                        self.id = uuid.uuid4().hex
-                    lines.append(f"{field_.name}: {self.id}")
-                case "title":
-                    pass  # handled before
-                case "type_":
-                    self.item_type = ItemType.FOLDER
-                    lines.append(f"{field_.name}: {self.item_type}")
-                case "updated_time":
-                    # required, even if empty
-                    value_raw = getattr(self, field_.name)
-                    value = "" if value_raw is None else value_raw
-                    lines.append(f"{field_.name}: {value}")
-                case _:
-                    value_raw = getattr(self, field_.name)
-                    if value_raw is not None:
-                        lines.append(f"{field_.name}: {value_raw}")
+            if field_.name == "id":
+                # ID is always required
+                if self.id is None:
+                    self.id = uuid.uuid4().hex
+                lines.append(f"{field_.name}: {self.id}")
+            elif field_.name == "title":
+                pass  # handled before
+            elif field_.name == "type_":
+                self.item_type = ItemType.FOLDER
+                lines.append(f"{field_.name}: {self.item_type}")
+            elif field_.name == "updated_time":
+                # required, even if empty
+                value_raw = getattr(self, field_.name)
+                value = "" if value_raw is None else value_raw
+                lines.append(f"{field_.name}: {value}")
+            else:
+                value_raw = getattr(self, field_.name)
+                if value_raw is not None:
+                    lines.append(f"{field_.name}: {value_raw}")
         return "\n".join(lines)
 
 
@@ -361,26 +359,25 @@ class TagData(BaseData):
         if self.title is not None:
             lines.extend([self.title, ""])
         for field_ in fields(self):
-            match field_.name:
-                case "id":
-                    # ID is always required
-                    if self.id is None:
-                        self.id = uuid.uuid4().hex
-                    lines.append(f"{field_.name}: {self.id}")
-                case "title":
-                    pass  # handled before
-                case "type_":
-                    self.item_type = ItemType.TAG
-                    lines.append(f"{field_.name}: {self.item_type}")
-                case "updated_time":
-                    # required, even if empty
-                    value_raw = getattr(self, field_.name)
-                    value = "" if value_raw is None else value_raw
-                    lines.append(f"{field_.name}: {value}")
-                case _:
-                    value_raw = getattr(self, field_.name)
-                    if value_raw is not None:
-                        lines.append(f"{field_.name}: {value_raw}")
+            if field_.name == "id":
+                # ID is always required
+                if self.id is None:
+                    self.id = uuid.uuid4().hex
+                lines.append(f"{field_.name}: {self.id}")
+            elif field_.name == "title":
+                pass  # handled before
+            elif field_.name == "type_":
+                self.item_type = ItemType.TAG
+                lines.append(f"{field_.name}: {self.item_type}")
+            elif field_.name == "updated_time":
+                # required, even if empty
+                value_raw = getattr(self, field_.name)
+                value = "" if value_raw is None else value_raw
+                lines.append(f"{field_.name}: {value}")
+            else:
+                value_raw = getattr(self, field_.name)
+                if value_raw is not None:
+                    lines.append(f"{field_.name}: {value_raw}")
         return "\n".join(lines)
 
 
@@ -402,24 +399,23 @@ class NoteTagData(BaseData):
     def serialize(self) -> str:
         lines = []
         for field_ in fields(self):
-            match field_.name:
-                case "id":
-                    # ID is always required
-                    if self.id is None:
-                        self.id = uuid.uuid4().hex
-                    lines.append(f"{field_.name}: {self.id}")
-                case "type_":
-                    self.item_type = ItemType.NOTE_TAG
-                    lines.append(f"{field_.name}: {self.item_type}")
-                case "updated_time":
-                    # required, even if empty
-                    value_raw = getattr(self, field_.name)
-                    value = "" if value_raw is None else value_raw
-                    lines.append(f"{field_.name}: {value}")
-                case _:
-                    value_raw = getattr(self, field_.name)
-                    if value_raw is not None:
-                        lines.append(f"{field_.name}: {value_raw}")
+            if field_.name == "id":
+                # ID is always required
+                if self.id is None:
+                    self.id = uuid.uuid4().hex
+                lines.append(f"{field_.name}: {self.id}")
+            elif field_.name == "type_":
+                self.item_type = ItemType.NOTE_TAG
+                lines.append(f"{field_.name}: {self.item_type}")
+            elif field_.name == "updated_time":
+                # required, even if empty
+                value_raw = getattr(self, field_.name)
+                value = "" if value_raw is None else value_raw
+                lines.append(f"{field_.name}: {value}")
+            else:
+                value_raw = getattr(self, field_.name)
+                if value_raw is not None:
+                    lines.append(f"{field_.name}: {value_raw}")
         return "\n".join(lines)
 
 

--- a/joppy/data_types.py
+++ b/joppy/data_types.py
@@ -74,6 +74,11 @@ class BaseData:
     type_: Optional[ItemType] = None
 
     def __post_init__(self) -> None:
+        # detect if data is encrypted
+        encryption_applied = getattr(self, "encryption_applied")
+        if encryption_applied is not None and bool(int(encryption_applied)):
+            raise NotImplementedError("Encryption is not supported")
+
         # Cast the basic joplin API datatypes to more convenient datatypes.
         for field_ in fields(self):
             value = getattr(self, field_.name)

--- a/joppy/data_types.py
+++ b/joppy/data_types.py
@@ -493,6 +493,32 @@ class EventData(BaseData):
         return {"id", "item_type", "item_id", "type", "created_time"}
 
 
+class LockType(enum.IntEnum):
+    NONE = 0
+    SYNC = 1
+    EXCLUSIVE = 2
+
+
+class LockClientType(enum.IntEnum):
+    DESKTOP = 1
+    MOBILE = 2
+    CLI = 3
+
+
+@dataclass
+class LockData(BaseData):
+    """
+    https://joplinapp.org/help/dev/spec/sync_lock#lock-files
+    https://github.com/laurent22/joplin/blob/b617a846964ea49be2ffefd31439e911ad84ed8c/packages/server/src/routes/api/locks.ts
+    """
+
+    id: Optional[str] = None
+    type: Optional[LockType] = None
+    clientId: Optional[str] = None
+    clientType: Optional[LockClientType] = None
+    updatedTime: Optional[datetime] = None
+
+
 @dataclass
 class UserData(BaseData):
     """
@@ -534,6 +560,7 @@ T = TypeVar(
     ResourceData,
     RevisionData,
     TagData,
+    LockData,
     UserData,
     str,
 )

--- a/joppy/data_types.py
+++ b/joppy/data_types.py
@@ -76,7 +76,7 @@ class BaseData:
 
     def __post_init__(self) -> None:
         # detect if data is encrypted
-        encryption_applied = getattr(self, "encryption_applied")
+        encryption_applied = getattr(self, "encryption_applied", False)
         if encryption_applied is not None and bool(int(encryption_applied)):
             raise NotImplementedError("Encryption is not supported")
 

--- a/joppy/data_types.py
+++ b/joppy/data_types.py
@@ -99,16 +99,21 @@ class BaseData:
                 # Exclude integer and empty string IDs.
                 if value and isinstance(value, str) and not is_id_valid(value):
                     raise ValueError("Invalid ID:", value)
-            elif field_.name.endswith("_time") or field_.name in (
-                "todo_due",
-                "todo_completed",
+            elif (
+                field_.name.endswith("_time")
+                or field_.name.endswith("Time")
+                or field_.name
+                in (
+                    "todo_due",
+                    "todo_completed",
+                )
             ):
                 try:
                     value_int = int(value)
                     casted_value = (
                         None
                         if value_int == 0
-                        else datetime.fromtimestamp(value_int / 1000.0)
+                        else datetime.utcfromtimestamp(value_int / 1000.0)
                     )
                     setattr(self, field_.name, casted_value)
                 except ValueError:

--- a/joppy/server_api.py
+++ b/joppy/server_api.py
@@ -163,11 +163,6 @@ class ApiBase:
 ##############################################################################
 
 
-# TODO
-class Event(ApiBase):
-    pass
-
-
 class Note(ApiBase):
     def add_note(self, **data: Any) -> str:
         """Add a note."""
@@ -286,11 +281,6 @@ class Revision(ApiBase):
         return dt.DataList(response["has_more"], response["cursor"], revisions)
 
 
-# TODO: Is there a search functionality?
-class Search(ApiBase):
-    pass
-
-
 class Tag(ApiBase):
     def add_tag(self, **data: Any) -> str:
         """Add a tag."""
@@ -338,7 +328,7 @@ class Tag(ApiBase):
         self.put(f"/api/items/root:/{id_server}:/content", data=request_data)
 
 
-class ServerApi(Event, Note, Notebook, Ping, Resource, Revision, Search, Tag):
+class ServerApi(Note, Notebook, Ping, Resource, Revision, Tag):
     """
     Collects all basic API functions and contains a few more useful methods.
     This should be the only class accessed from the users.
@@ -399,11 +389,6 @@ class ServerApi(Event, Note, Notebook, Ping, Resource, Revision, Search, Tag):
         for tag in self.get_all_tags():
             assert tag.id is not None
             self.delete_tag(tag.id)
-
-    # TODO
-    # def get_all_events(self, **query: Any) -> List[dt.EventData]:
-    #     """Get all events, unpaginated."""
-    #     return self._unpaginate(self.get_events, **query)
 
     def get_all_notes(self, **query: Any) -> List[dt.NoteData]:
         """Get all notes, unpaginated."""

--- a/joppy/server_api.py
+++ b/joppy/server_api.py
@@ -215,18 +215,18 @@ class ApiBase:
         """
         self.delete(f"/api/locks/{lock_type}_{client_type}_{client_id}")
 
-    def _get_locks(self) -> dt.DataList[dt.LockData]:
+    def _get_locks(self, **query: dt.JoplinTypes) -> dt.DataList[dt.LockData]:
         """
         Get locks, paginated.
         To get all locks (unpaginated), use "_get_all_locks()".
         """
-        response = self.get("/api/locks").json()
+        response = self.get("/api/locks", query=query).json()
         response["items"] = [dt.LockData(**item) for item in response["items"]]
         return dt.DataList[dt.LockData](**response)
 
-    def _get_all_locks(self, **query: Any) -> List[dt.LockData]:
+    def _get_all_locks(self) -> List[dt.LockData]:
         """Get all locks, unpaginated."""
-        return tools._unpaginate(self._get_locks, **query)
+        return tools._unpaginate(self._get_locks)
 
     def _is_lock_active(self, updated_time: datetime.datetime) -> bool:
         return updated_time + self.lock_ttl > datetime.datetime.utcnow()
@@ -313,8 +313,8 @@ class Note(ApiBase):
         response = self.get(f"/api/items/root:/{add_suffix(id_)}:/content")
         return cast(dt.NoteData, deserialize(response.text))
 
-    def get_notes(self) -> dt.DataList[dt.NoteData]:
-        response = self.get("/api/items/root:/:/children").json()
+    def get_notes(self, **query: dt.JoplinTypes) -> dt.DataList[dt.NoteData]:
+        response = self.get("/api/items/root:/:/children", query=query).json()
         # TODO: Is this the best practice?
         notes = []
         for item in response["items"]:
@@ -356,8 +356,8 @@ class Notebook(ApiBase):
         response = self.get(f"/api/items/root:/{add_suffix(id_)}:/content")
         return cast(dt.NotebookData, deserialize(response.text))
 
-    def get_notebooks(self) -> dt.DataList[dt.NotebookData]:
-        response = self.get("/api/items/root:/:/children").json()
+    def get_notebooks(self, **query: dt.JoplinTypes) -> dt.DataList[dt.NotebookData]:
+        response = self.get("/api/items/root:/:/children", query=query).json()
         # TODO: Is this the best practice?
         notebooks = []
         for item in response["items"]:
@@ -423,12 +423,12 @@ class Resource(ApiBase):
         """Get the resource with the given ID in binary format."""
         return self.get(f"/api/items/root:/.resource/{id_}:/content").content
 
-    def get_resources(self) -> dt.DataList[dt.ResourceData]:
+    def get_resources(self, **query: dt.JoplinTypes) -> dt.DataList[dt.ResourceData]:
         """
         Get resources, paginated.
         To get all resources (unpaginated), use "get_all_resources()".
         """
-        response = self.get("/api/items/root:/:/children").json()
+        response = self.get("/api/items/root:/:/children", query=query).json()
         # TODO: Is this the best practice?
         resources = []
         for item in response["items"]:
@@ -449,13 +449,13 @@ class Revision(ApiBase):
         """Delete a revision."""
         self.delete(f"/api/items/root:/{add_suffix(id_)}:")
 
-    def get_revision(self, id_: str, **query: Any) -> dt.RevisionData:
+    def get_revision(self, id_: str) -> dt.RevisionData:
         """Get the revision with the given ID."""
         response = self.get(f"/api/items/root:/{add_suffix(id_)}:/content")
         return cast(dt.RevisionData, deserialize(response.text))
 
     def get_revisions(self, **query: Any) -> dt.DataList[dt.RevisionData]:
-        response = self.get("/api/items/root:/:/children").json()
+        response = self.get("/api/items/root:/:/children", query=query).json()
         # TODO: Is this the best practice?
         revisions = []
         for item in response["items"]:
@@ -486,12 +486,12 @@ class Tag(ApiBase):
         response = self.get(f"/api/items/root:/{add_suffix(id_)}:/content")
         return cast(dt.TagData, deserialize(response.text))
 
-    def get_tags(self) -> dt.DataList[dt.TagData]:
+    def get_tags(self, **query: dt.JoplinTypes) -> dt.DataList[dt.TagData]:
         """
         Get tags, paginated.
         To get all tags (unpaginated), use "get_all_tags()".
         """
-        response = self.get("/api/items/root:/:/children").json()
+        response = self.get("/api/items/root:/:/children", query=query).json()
         # TODO: Is this the best practice?
         tags = []
         for item in response["items"]:
@@ -514,12 +514,12 @@ class Tag(ApiBase):
 
 
 class User(ApiBase):
-    def get_users(self) -> dt.DataList[dt.UserData]:
+    def get_users(self, **query: dt.JoplinTypes) -> dt.DataList[dt.UserData]:
         """
         Get users, paginated.
         To get all users (unpaginated), use "get_all_users()".
         """
-        response = self.get("/api/users").json()
+        response = self.get("/api/users", query=query).json()
         response["items"] = [dt.UserData(**item) for item in response["items"]]
         return dt.DataList[dt.UserData](**response)
 
@@ -585,29 +585,29 @@ class ServerApi(Note, Notebook, Ping, Resource, Revision, Tag, User):
             assert tag.id is not None
             self.delete_tag(tag.id)
 
-    def get_all_notes(self, **query: Any) -> List[dt.NoteData]:
+    def get_all_notes(self) -> List[dt.NoteData]:
         """Get all notes, unpaginated."""
-        return tools._unpaginate(self.get_notes, **query)
+        return tools._unpaginate(self.get_notes)
 
-    def get_all_notebooks(self, **query: Any) -> List[dt.NotebookData]:
+    def get_all_notebooks(self) -> List[dt.NotebookData]:
         """Get all notebooks, unpaginated."""
-        return tools._unpaginate(self.get_notebooks, **query)
+        return tools._unpaginate(self.get_notebooks)
 
-    def get_all_resources(self, **query: Any) -> List[dt.ResourceData]:
+    def get_all_resources(self) -> List[dt.ResourceData]:
         """Get all resources, unpaginated."""
-        return tools._unpaginate(self.get_resources, **query)
+        return tools._unpaginate(self.get_resources)
 
-    def get_all_revisions(self, **query: Any) -> List[dt.RevisionData]:
+    def get_all_revisions(self,) -> List[dt.RevisionData]:
         """Get all revisions, unpaginated."""
-        return tools._unpaginate(self.get_revisions, **query)
+        return tools._unpaginate(self.get_revisions)
 
-    def get_all_tags(self, **query: Any) -> List[dt.TagData]:
+    def get_all_tags(self) -> List[dt.TagData]:
         """Get all tags, unpaginated."""
-        return tools._unpaginate(self.get_tags, **query)
+        return tools._unpaginate(self.get_tags)
 
-    def get_all_users(self, **query: Any) -> List[dt.UserData]:
+    def get_all_users(self) -> List[dt.UserData]:
         """Get all users, unpaginated."""
-        return tools._unpaginate(self.get_users, **query)
+        return tools._unpaginate(self.get_users)
 
     def get_current_user(self) -> Optional[dt.UserData]:
         """https://joplinapp.org/help/dev/spec/server_user_status/#user-status"""

--- a/joppy/server_api.py
+++ b/joppy/server_api.py
@@ -182,11 +182,11 @@ class Note(ApiBase):
         self.delete(f"/api/items/root:/{add_suffix(id_)}:")
 
     def get_note(self, id_: str) -> dt.NoteData:
-        response = self.get(f"/api/items/{add_suffix(id_)}/content")
+        response = self.get(f"/api/items/root:/{add_suffix(id_)}:/content")
         return cast(dt.NoteData, deserialize(response.text))
 
     def get_notes(self) -> dt.DataList[dt.NoteData]:
-        response = self.get("/api/items/root:/:/children").json()
+        response = self.get(f"/api/items/root:/:/children").json()
         # TODO: Is this the best practice?
         notes = []
         for item in response["items"]:
@@ -225,11 +225,11 @@ class Notebook(ApiBase):
         self.delete(f"/api/items/root:/{add_suffix(id_)}:")
 
     def get_notebook(self, id_: str) -> dt.NotebookData:
-        response = self.get(f"/api/items/{add_suffix(id_)}/content")
+        response = self.get(f"/api/items/root:/{add_suffix(id_)}:/content")
         return cast(dt.NotebookData, deserialize(response.text))
 
     def get_notebooks(self) -> dt.DataList[dt.NotebookData]:
-        response = self.get("/api/items/root:/:/children").json()
+        response = self.get(f"/api/items/root:/:/children").json()
         # TODO: Is this the best practice?
         notebooks = []
         for item in response["items"]:
@@ -288,7 +288,7 @@ class Resource(ApiBase):
 
     def get_resource(self, id_: str) -> dt.ResourceData:
         """Get metadata about the resource with the given ID."""
-        response = self.get(f"/api/items/{add_suffix(id_)}/content")
+        response = self.get(f"/api/items/root:/{add_suffix(id_)}:/content")
         return cast(dt.ResourceData, deserialize(response.text))
 
     def get_resource_file(self, id_: str) -> bytes:
@@ -323,7 +323,7 @@ class Revision(ApiBase):
 
     def get_revision(self, id_: str, **query: Any) -> dt.RevisionData:
         """Get the revision with the given ID."""
-        response = self.get(f"/api/items/{add_suffix(id_)}/content")
+        response = self.get(f"/api/items/root:/{add_suffix(id_)}:/content")
         return cast(dt.RevisionData, deserialize(response.text))
 
     def get_revisions(self, **query: Any) -> dt.DataList[dt.RevisionData]:
@@ -355,7 +355,7 @@ class Tag(ApiBase):
 
     def get_tag(self, id_: str) -> dt.TagData:
         """Get the tag with the given ID."""
-        response = self.get(f"/api/items/{add_suffix(id_)}/content")
+        response = self.get(f"/api/items/root:/{add_suffix(id_)}:/content")
         return cast(dt.TagData, deserialize(response.text))
 
     def get_tags(self) -> dt.DataList[dt.TagData]:

--- a/joppy/server_api.py
+++ b/joppy/server_api.py
@@ -21,9 +21,8 @@ LOGGER = logging.getLogger("joppy")
 
 def deserialize(body: str) -> Optional[dt.AnyData]:
     """Deserialize server data from string to a known data type."""
-    # https://github.com/laurent22/joplin/blob/b617a846964ea49be2ffefd31439e911ad84ed8c/packages/lib/models/BaseItem.ts#L549-L596
-    body_splitted = body.split("\n\n")
 
+    # https://github.com/laurent22/joplin/blob/b617a846964ea49be2ffefd31439e911ad84ed8c/packages/lib/models/BaseItem.ts#L549-L596
     def extract_metadata(serialized_metadata: str) -> Dict[Any, Any]:
         metadata = {}
         for line in serialized_metadata.split("\n"):
@@ -33,23 +32,23 @@ def deserialize(body: str) -> Optional[dt.AnyData]:
             metadata[key] = value
         return metadata
 
-    if len(body_splitted) == 1:
+    metadata_splitted = body.rsplit("\n\n", 1)
+    if len(metadata_splitted) == 1:
         # metadata only
         title = None
         note_body = None
-        metadata = extract_metadata(body_splitted[0])
-    elif len(body_splitted) == 2:
-        # title + metadata
-        title = body_splitted[0]
-        note_body = None
-        metadata = extract_metadata(body_splitted[1])
-    elif len(body_splitted) == 3:
-        # title + body + metadata
-        title = body_splitted[0]
-        note_body = body_splitted[1]
-        metadata = extract_metadata(body_splitted[2])
+        metadata = extract_metadata(metadata_splitted[0])
     else:
-        print("TODO: ", body_splitted)
+        metadata = extract_metadata(metadata_splitted[1])
+        title_splitted = metadata_splitted[0].split("\n\n", 1)
+        if len(title_splitted) == 1:
+            # title + metadata
+            title = title_splitted[0]
+            note_body = None
+        else:
+            # title + body + metadata
+            title = title_splitted[0]
+            note_body = title_splitted[1]
 
     if title is not None:
         metadata["title"] = title

--- a/joppy/server_api.py
+++ b/joppy/server_api.py
@@ -164,9 +164,10 @@ class ApiBase:
 
 
 class Note(ApiBase):
-    def add_note(self, **data: Any) -> str:
+    def add_note(self, parent_id, **data: Any) -> str:
         """Add a note."""
-        note_data = dt.NoteData(**data)
+        # Parent ID is required. Else the notes are created at root.
+        note_data = dt.NoteData(parent_id=parent_id, **data)
         request_data = note_data.serialize()
         assert note_data.id is not None
         self.put(

--- a/joppy/server_api.py
+++ b/joppy/server_api.py
@@ -33,43 +33,43 @@ def deserialize(body: str) -> Optional[dt.AnyData]:
             metadata[key] = value
         return metadata
 
-    match len(body_splitted):
-        case 1:
-            # metadata only
-            title = None
-            note_body = None
-            metadata = extract_metadata(body_splitted[0])
-        case 2:
-            # title + metadata
-            title = body_splitted[0]
-            note_body = None
-            metadata = extract_metadata(body_splitted[1])
-        case 3:
-            # title + body + metadata
-            title = body_splitted[0]
-            note_body = body_splitted[1]
-            metadata = extract_metadata(body_splitted[2])
-        case _:
-            print("TODO: ", body_splitted)
+    if len(body_splitted) == 1:
+        # metadata only
+        title = None
+        note_body = None
+        metadata = extract_metadata(body_splitted[0])
+    elif len(body_splitted) == 2:
+        # title + metadata
+        title = body_splitted[0]
+        note_body = None
+        metadata = extract_metadata(body_splitted[1])
+    elif len(body_splitted) == 3:
+        # title + body + metadata
+        title = body_splitted[0]
+        note_body = body_splitted[1]
+        metadata = extract_metadata(body_splitted[2])
+    else:
+        print("TODO: ", body_splitted)
+
     if title is not None:
         metadata["title"] = title
     if note_body is not None:
         metadata["body"] = note_body
 
-    match dt.ItemType(int(metadata["type_"])):
-        case dt.ItemType.NOTE:
-            return dt.NoteData(**metadata)
-        case dt.ItemType.FOLDER:
-            return dt.NotebookData(**metadata)
-        case dt.ItemType.TAG:
-            return dt.TagData(**metadata)
-        case dt.ItemType.NOTE_TAG:
-            return dt.NoteTagData(**metadata)
-        case dt.ItemType.REVISION:
-            # ignore revisions for now
-            pass
-        case _:
-            print("TODO: ", dt.ItemType(int(metadata["type_"])))
+    item_type = dt.ItemType(int(metadata["type_"]))
+    if item_type == dt.ItemType.NOTE:
+        return dt.NoteData(**metadata)
+    elif item_type == dt.ItemType.FOLDER:
+        return dt.NotebookData(**metadata)
+    elif item_type == dt.ItemType.TAG:
+        return dt.TagData(**metadata)
+    elif item_type == dt.ItemType.NOTE_TAG:
+        return dt.NoteTagData(**metadata)
+    elif item_type == dt.ItemType.REVISION:
+        # ignore revisions for now
+        pass
+    else:
+        print("TODO: ", dt.ItemType(int(metadata["type_"])))
     return None
 
 

--- a/joppy/server_api.py
+++ b/joppy/server_api.py
@@ -1,0 +1,429 @@
+import logging
+import pathlib
+from typing import Any, cast, Dict, List, Optional
+
+import requests
+
+import joppy.data_types as dt
+from joppy import tools
+
+
+# Use a global session object for better performance.
+# Define it globally to avoid "ResourceWarning".
+SESSION = requests.Session()
+
+# Don't spam the log. See: https://stackoverflow.com/a/11029841/7410886.
+logging.getLogger("requests").setLevel(logging.WARNING)
+logging.getLogger("urllib3").setLevel(logging.WARNING)
+
+LOGGER = logging.getLogger("joppy")
+
+
+def deserialize(body: str) -> Optional[dt.AnyData]:
+    """Deserialize server data from string to a known data type."""
+    # https://github.com/laurent22/joplin/blob/b617a846964ea49be2ffefd31439e911ad84ed8c/packages/lib/models/BaseItem.ts#L549-L596
+    body_splitted = body.split("\n\n")
+
+    def extract_metadata(serialized_metadata: str) -> Dict[Any, Any]:
+        metadata = {}
+        for line in serialized_metadata.split("\n"):
+            key, value = line.split(": ", 1)
+            if not value:
+                continue
+            metadata[key] = value
+        return metadata
+
+    match len(body_splitted):
+        case 1:
+            # metadata only
+            title = None
+            note_body = None
+            metadata = extract_metadata(body_splitted[0])
+        case 2:
+            # title + metadata
+            title = body_splitted[0]
+            note_body = None
+            metadata = extract_metadata(body_splitted[1])
+        case 3:
+            # title + body + metadata
+            title = body_splitted[0]
+            note_body = body_splitted[1]
+            metadata = extract_metadata(body_splitted[2])
+        case _:
+            print("TODO: ", body_splitted)
+    if title is not None:
+        metadata["title"] = title
+    if note_body is not None:
+        metadata["body"] = note_body
+
+    match dt.ItemType(int(metadata["type_"])):
+        case dt.ItemType.NOTE:
+            return dt.NoteData(**metadata)
+        case dt.ItemType.FOLDER:
+            return dt.NotebookData(**metadata)
+        case dt.ItemType.TAG:
+            return dt.TagData(**metadata)
+        case dt.ItemType.NOTE_TAG:
+            return dt.NoteTagData(**metadata)
+        case dt.ItemType.REVISION:
+            # ignore revisions for now
+            pass
+        case _:
+            print("TODO: ", dt.ItemType(int(metadata["type_"])))
+    return None
+
+
+def add_suffix(string: str, suffix: str = ".md") -> str:
+    """Add a suffix."""
+    return str(pathlib.Path(string).with_suffix(suffix))
+
+
+def remove_suffix(string: str) -> str:
+    """Remove the suffix."""
+    return str(pathlib.Path(string).with_suffix(""))
+
+
+##############################################################################
+# Base wrapper that manages the requests to the client REST API.
+##############################################################################
+
+
+class ApiBase:
+    """Contains the basic requests of the server REST API."""
+
+    def __init__(
+        self,
+        user: str = "admin@localhost",
+        password: str = "admin",
+        url: str = "http://localhost:22300",
+        encryption_key: Optional[str] = None,
+    ) -> None:
+        self.url = url
+        self.encryption_key = encryption_key  # TODO
+
+        # cookie is saved in session and used for the next requests
+        self.post("/login", data={"email": user, "password": password})
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        query: Optional[dt.JoplinKwargs] = None,
+        data: Any = None,
+        files: Optional[Dict[str, Any]] = None,
+        headers: Optional[Dict[str, Any]] = None,
+    ) -> requests.models.Response:
+        LOGGER.debug(f"API: {method} request: path={path}, query={query}, data={data}")
+        if query is None:
+            query = {}
+        query_str = "&".join([f"{key}={val}" for key, val in query.items()])
+
+        try:
+            response: requests.models.Response = getattr(SESSION, method)(
+                f"{self.url}{path}?{query_str}",
+                data=data,
+                files=files,
+                headers=headers,
+            )
+            LOGGER.debug(f"API: response {response.text}")
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as err:
+            err.args = err.args + (response.text,)
+            raise
+        return response
+
+    def delete(
+        self, path: str, query: Optional[dt.JoplinKwargs] = None
+    ) -> requests.models.Response:
+        """Convenience method to issue a delete request."""
+        return self._request("delete", path, query=query)
+
+    def get(
+        self, path: str, query: Optional[dt.JoplinKwargs] = None
+    ) -> requests.models.Response:
+        """Convenience method to issue a get request."""
+        return self._request("get", path, query=query)
+
+    def post(
+        self,
+        path: str,
+        data: Optional[dt.JoplinKwargs] = None,
+        files: Optional[Dict[str, Any]] = None,
+    ) -> requests.models.Response:
+        """Convenience method to issue a post request."""
+        return self._request("post", path, data=data, files=files)
+
+    def put(self, path: str, data: str) -> requests.models.Response:
+        """Convenience method to issue a put request."""
+        return self._request(
+            "put", path, data=data, headers={"Content-Type": "application/octet-stream"}
+        )
+
+
+##############################################################################
+# Specific classes
+##############################################################################
+
+
+# TODO
+class Event(ApiBase):
+    pass
+
+
+class Note(ApiBase):
+    def add_note(self, **data: Any) -> str:
+        """Add a note."""
+        note_data = dt.NoteData(**data)
+        request_data = note_data.serialize()
+        assert note_data.id is not None
+        self.put(
+            f"/api/items/root:/{add_suffix(note_data.id)}:/content", data=request_data
+        )
+        return note_data.id
+
+    def delete_note(self, id_: str) -> None:
+        """Delete a note."""
+        self.delete(f"/api/items/{add_suffix(id_)}")
+
+    def get_note(self, id_: str) -> dt.NoteData:
+        response = self.get(f"/api/items/{add_suffix(id_)}/content")
+        return cast(dt.NoteData, deserialize(response.text))
+
+    def get_notes(self) -> dt.DataList[dt.NoteData]:
+        response = self.get("/api/items/root:/:/children").json()
+        # TODO: Is this the best practice?
+        notes = []
+        for item in response["items"]:
+            if item["name"].endswith(".md"):
+                item_complete = self.get_note(remove_suffix(item["name"]))
+                if isinstance(item_complete, dt.NoteData):
+                    notes.append(item_complete)
+        return dt.DataList(response["has_more"], response["cursor"], notes)
+
+    def modify_note(self, id_: str, **data: Any) -> None:
+        """Modify a note."""
+        # TODO: Without fetching the orginal note, this would be replacing,
+        # not modifying.
+        id_server = add_suffix(id_)
+        note_data = self.get_note(id_server)
+        for key, value in data.items():
+            setattr(note_data, key, value)
+        request_data = note_data.serialize()
+        self.put(f"/api/items/root:/{id_server}:/content", data=request_data)
+
+
+class Notebook(ApiBase):
+    def add_notebook(self, **data: Any) -> str:
+        """Add a notebook."""
+        notebook_data = dt.NotebookData(**data)
+        request_data = notebook_data.serialize()
+        assert notebook_data.id is not None
+        self.put(
+            f"/api/items/root:/{add_suffix(notebook_data.id)}:/content",
+            data=request_data,
+        )
+        return notebook_data.id
+
+    def delete_notebook(self, id_: str) -> None:
+        """Delete a notebook."""
+        self.delete(f"/api/items/{add_suffix(id_)}")
+
+    def get_notebook(self, id_: str) -> dt.NotebookData:
+        response = self.get(f"/api/items/{add_suffix(id_)}/content")
+        return cast(dt.NotebookData, deserialize(response.text))
+
+    def get_notebooks(self) -> dt.DataList[dt.NotebookData]:
+        response = self.get("/api/items/root:/:/children").json()
+        # TODO: Is this the best practice?
+        notebooks = []
+        for item in response["items"]:
+            if item["name"].endswith(".md"):
+                item_complete = self.get_notebook(remove_suffix(item["name"]))
+                if isinstance(item_complete, dt.NotebookData):
+                    notebooks.append(item_complete)
+        return dt.DataList(response["has_more"], response["cursor"], notebooks)
+
+    def modify_notebook(self, id_: str, **data: Any) -> None:
+        """Modify a notebook."""
+        # TODO: Without fetching the orginal notebook, this would be replacing,
+        # not modifying.
+        id_server = add_suffix(id_)
+        notebook_data = self.get_notebook(id_server)
+        for key, value in data.items():
+            setattr(notebook_data, key, value)
+        request_data = notebook_data.serialize()
+        self.put(f"/api/items/root:/{id_server}:/content", data=request_data)
+
+
+class Ping(ApiBase):
+    def ping(self) -> requests.models.Response:
+        """Ping the API."""
+        return self.get("/api/ping")
+
+
+# TODO
+class Resource(ApiBase):
+    pass
+
+
+class Revision(ApiBase):
+    def delete_revision(self, id_: str) -> None:
+        """Delete a revision."""
+        self.delete(f"/api/items/{add_suffix(id_)}")
+
+    def get_revision(self, id_: str, **query: Any) -> dt.RevisionData:
+        """Get the revision with the given ID."""
+        response = self.get(f"/api/items/{add_suffix(id_)}/content")
+        return cast(dt.RevisionData, deserialize(response.text))
+
+    def get_revisions(self, **query: Any) -> dt.DataList[dt.RevisionData]:
+        response = self.get("/api/items/root:/:/children").json()
+        # TODO: Is this the best practice?
+        revisions = []
+        for item in response["items"]:
+            if item["name"].endswith(".md"):
+                item_complete = self.get_revision(remove_suffix(item["name"]))
+                if isinstance(item_complete, dt.RevisionData):
+                    revisions.append(item_complete)
+        return dt.DataList(response["has_more"], response["cursor"], revisions)
+
+
+# TODO: Is there a search functionality?
+class Search(ApiBase):
+    pass
+
+
+class Tag(ApiBase):
+    def add_tag(self, **data: Any) -> str:
+        """Add a tag."""
+        tag_data = dt.TagData(**data)
+        request_data = tag_data.serialize()
+        assert tag_data.id is not None
+        self.put(
+            f"/api/items/root:/{add_suffix(tag_data.id)}:/content", data=request_data
+        )
+        return tag_data.id
+
+    def delete_tag(self, id_: str) -> None:
+        """Delete a tag."""
+        self.delete(f"/api/items/{add_suffix(id_)}")
+
+    def get_tag(self, id_: str) -> dt.TagData:
+        """Get the tag with the given ID."""
+        response = self.get(f"/api/items/{add_suffix(id_)}/content")
+        return cast(dt.TagData, deserialize(response.text))
+
+    def get_tags(self) -> dt.DataList[dt.TagData]:
+        """
+        Get tags, paginated. If a note is given, return the corresponding tags.
+        To get all tags (unpaginated), use "get_all_tags()".
+        """
+        response = self.get("/api/items/root:/:/children").json()
+        # TODO: Is this the best practice?
+        tags = []
+        for item in response["items"]:
+            if item["name"].endswith(".md"):
+                item_complete = self.get_tag(remove_suffix(item["name"]))
+                if isinstance(item_complete, dt.TagData):
+                    tags.append(item_complete)
+        return dt.DataList(response["has_more"], response["cursor"], tags)
+
+    def modify_tag(self, id_: str, **data: Any) -> None:
+        """Modify a tag."""
+        # TODO: Without fetching the orginal tag, this would be replacing,
+        # not modifying.
+        id_server = add_suffix(id_)
+        tag_data = self.get_tag(id_server)
+        for key, value in data.items():
+            setattr(tag_data, key, value)
+        request_data = tag_data.serialize()
+        self.put(f"/api/items/root:/{id_server}:/content", data=request_data)
+
+
+class ServerApi(Event, Note, Notebook, Ping, Resource, Revision, Search, Tag):
+    """
+    Collects all basic API functions and contains a few more useful methods.
+    This should be the only class accessed from the users.
+    """
+
+    def add_tag_to_note(self, tag_id: str, note_id: str) -> str:
+        """Add a tag to a given note."""
+        note_tag_data = dt.NoteTagData(tag_id=tag_id, note_id=note_id)
+        request_data = note_tag_data.serialize()
+        assert note_tag_data.id is not None
+        self.put(
+            f"/api/items/root:/{add_suffix(note_tag_data.id)}:/content",
+            data=request_data,
+        )
+        return note_tag_data.id
+
+    # TODO
+    # def add_resource_to_note(self, resource_id: str, note_id: str) -> None:
+    #     """Add a resource to a given note."""
+    #     note = self.get_note(id_=note_id, fields="body")
+    #     resource = self.get_resource(id_=resource_id, fields="title,mime")
+    #     # TODO: Use "assertIsNotNone()" when
+    #     # https://github.com/python/mypy/issues/5528 is resolved.
+    #     assert resource.mime is not None
+    #     image_prefix = "!" if resource.mime.startswith("image/") else ""
+    #     body_with_attachment = (
+    #         f"{note.body}\n{image_prefix}[{resource.title}](:/{resource_id})"
+    #     )
+    #     self.modify_note(note_id, body=body_with_attachment)
+
+    def delete_all_notes(self) -> None:
+        """Delete all notes permanently."""
+        for note in self.get_all_notes():
+            assert note.id is not None
+            self.delete_note(note.id)
+
+    def delete_all_notebooks(self) -> None:
+        """Delete all notebooks permanently."""
+        for notebook in self.get_all_notebooks():
+            assert notebook.id is not None
+            self.delete_notebook(notebook.id)
+
+    def delete_all_resources(self) -> None:
+        """Delete all resources."""
+        pass  # TODO
+        # for resource in self.get_all_resources():
+        #     assert resource.id is not None
+        #     self.delete_resource(resource.id)
+
+    def delete_all_revisions(self) -> None:
+        """Delete all revisions."""
+        for revision in self.get_all_revisions():
+            assert revision.id is not None
+            self.delete_revision(revision.id)
+
+    def delete_all_tags(self) -> None:
+        """Delete all tags."""
+        for tag in self.get_all_tags():
+            assert tag.id is not None
+            self.delete_tag(tag.id)
+
+    # TODO
+    # def get_all_events(self, **query: Any) -> List[dt.EventData]:
+    #     """Get all events, unpaginated."""
+    #     return self._unpaginate(self.get_events, **query)
+
+    def get_all_notes(self, **query: Any) -> List[dt.NoteData]:
+        """Get all notes, unpaginated."""
+        return tools._unpaginate(self.get_notes, **query)
+
+    def get_all_notebooks(self, **query: Any) -> List[dt.NotebookData]:
+        """Get all notebooks, unpaginated."""
+        return tools._unpaginate(self.get_notebooks, **query)
+
+    def get_all_resources(self, **query: Any) -> List[dt.ResourceData]:
+        """Get all resources, unpaginated."""
+        return []  # TODO
+        # return tools._unpaginate(self.get_resources, **query)
+
+    def get_all_revisions(self, **query: Any) -> List[dt.RevisionData]:
+        """Get all revisions, unpaginated."""
+        return tools._unpaginate(self.get_revisions, **query)
+
+    def get_all_tags(self, **query: Any) -> List[dt.TagData]:
+        """Get all tags, unpaginated."""
+        return tools._unpaginate(self.get_tags, **query)

--- a/joppy/server_api.py
+++ b/joppy/server_api.py
@@ -582,7 +582,7 @@ class ServerApi(Note, Notebook, Ping, Resource, Revision, Tag, Lock, User):
         self.delete_lock(dt.LockType.SYNC, dt.LockClientType.DESKTOP, self.client_id)
 
     @contextmanager
-    def sync_lock(self):
+    def sync_lock(self) -> Any:
         self.acquire_sync_lock()
         if self.current_sync_lock is None:
             raise Exception("Couldn't aqcuire sync lock")

--- a/joppy/server_api.py
+++ b/joppy/server_api.py
@@ -96,10 +96,8 @@ class ApiBase:
         user: str = "admin@localhost",
         password: str = "admin",
         url: str = "http://localhost:22300",
-        encryption_key: Optional[str] = None,
     ) -> None:
         self.url = url
-        self.encryption_key = encryption_key  # TODO
 
         # cookie is saved in session and used for the next requests
         self.post("/login", data={"email": user, "password": password})

--- a/joppy/tools.py
+++ b/joppy/tools.py
@@ -1,9 +1,27 @@
 """Helper functions for the API."""
 
 import base64
+from typing import Callable, List
+
+import joppy.data_types as dt
 
 
 def encode_base64(filepath: str) -> str:
     """Encode an arbitrary file to base64."""
     with open(filepath, "rb") as img_file:
         return base64.b64encode(img_file.read()).decode("utf-8")
+
+
+def _unpaginate(
+    func: Callable[..., dt.DataList[dt.T]], **query: dt.JoplinTypes
+) -> List[dt.T]:
+    """Calls an Joplin endpoint until it's response doesn't contain more data."""
+    response = func(**query)
+    items = response.items
+    page = 1  # pages are one based
+    while response.has_more:
+        page += 1
+        query["page"] = page
+        response = func(**query)
+        items.extend(response.items)
+    return items

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ ignore_missing_imports = True
 [mypy-setuptools.*]
 ignore_missing_imports = True
 # Signature types of tests don't matter.
-[mypy-test.test_api.*]
+[mypy-test.*]
 disallow_untyped_defs = False
 [mypy-xvfbwrapper.*]
 ignore_missing_imports = True

--- a/test/common.py
+++ b/test/common.py
@@ -3,6 +3,7 @@ import logging
 import os
 import random
 import string
+import tempfile
 from typing import Any, Iterable, Tuple
 import unittest
 
@@ -17,6 +18,20 @@ logging.basicConfig(
 LOGGER = logging.getLogger("joppy")
 
 SLOW_TESTS = bool(os.getenv("SLOW_TESTS", ""))
+
+
+def with_resource(func):
+    """Create a dummy resource and return its filename."""
+
+    def inner_decorator(self, *args, **kwargs):
+        # TODO: Check why TemporaryFile() doesn't work.
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            filename = f"{tmpdirname}/dummy.raw"
+            open(filename, "w").close()
+
+            return func(self, *args, **kwargs, filename=filename)
+
+    return inner_decorator
 
 
 class Base(unittest.TestCase):

--- a/test/common.py
+++ b/test/common.py
@@ -42,12 +42,13 @@ class Base(unittest.TestCase):
 
         LOGGER.debug("Test: %s", self.id())
 
-        self.api.delete_all_notebooks()
-        self.api.delete_all_notes()
-        self.api.delete_all_resources()
-        self.api.delete_all_tags()
-        # Delete revisions last to cover all previous deletions.
-        self.api.delete_all_revisions()
+        with self.api.sync_lock():
+            self.api.delete_all_notebooks()
+            self.api.delete_all_notes()
+            self.api.delete_all_resources()
+            self.api.delete_all_tags()
+            # Delete revisions last to cover all previous deletions.
+            self.api.delete_all_revisions()
 
     @staticmethod
     def get_random_id() -> str:

--- a/test/common.py
+++ b/test/common.py
@@ -1,0 +1,69 @@
+import itertools
+import logging
+import os
+import random
+import string
+from typing import Any, Iterable, Tuple
+import unittest
+
+
+os.makedirs("test_output", exist_ok=True)
+logging.basicConfig(
+    filename="test_output/test.log",
+    filemode="w",
+    format="%(asctime)s [%(levelname)s]: %(message)s",
+    level=logging.DEBUG,
+)
+LOGGER = logging.getLogger("joppy")
+
+SLOW_TESTS = bool(os.getenv("SLOW_TESTS", ""))
+
+
+class Base(unittest.TestCase):
+    api: Any
+
+    def setUp(self) -> None:
+        super().setUp()
+
+        LOGGER.debug("Test: %s", self.id())
+
+        self.api.delete_all_notebooks()
+        self.api.delete_all_notes()
+        self.api.delete_all_resources()
+        self.api.delete_all_tags()
+        # Delete revisions last to cover all previous deletions.
+        self.api.delete_all_revisions()
+
+    @staticmethod
+    def get_random_id() -> str:
+        """Return a random, valid ID."""
+        # https://stackoverflow.com/a/2782859/7410886
+        return f"{random.randrange(16**32):032x}"
+
+    @staticmethod
+    def get_random_string(length: int = 8, exclude: str = "") -> str:
+        """Return a random string."""
+        characters = string.printable
+        for character in exclude:
+            characters = characters.replace(character, "")
+        random_string = "".join(random.choice(characters) for _ in range(length))
+        LOGGER.debug("Test: random string: %s", random_string)
+        return random_string
+
+    @staticmethod
+    def get_combinations(
+        iterable: Iterable[str], max_combinations: int = 100
+    ) -> Iterable[Tuple[str, ...]]:
+        """Get some combinations of an iterable."""
+        # https://stackoverflow.com/a/10465588
+        # TODO: Randomize fully. For now the combinations are sorted by length.
+        list_ = list(iterable)
+        lengths = list(range(1, len(list_) + 1))
+        random.shuffle(lengths)
+        combinations = itertools.chain.from_iterable(
+            itertools.combinations(list_, r)
+            for r in lengths
+            # shuffle each iteration
+            if random.shuffle(list_) is None
+        )
+        return itertools.islice(combinations, max_combinations)

--- a/test/common.py
+++ b/test/common.py
@@ -42,13 +42,12 @@ class Base(unittest.TestCase):
 
         LOGGER.debug("Test: %s", self.id())
 
-        with self.api.sync_lock():
-            self.api.delete_all_notebooks()
-            self.api.delete_all_notes()
-            self.api.delete_all_resources()
-            self.api.delete_all_tags()
-            # Delete revisions last to cover all previous deletions.
-            self.api.delete_all_revisions()
+        self.api.delete_all_notebooks()
+        self.api.delete_all_notes()
+        self.api.delete_all_resources()
+        self.api.delete_all_tags()
+        # Delete revisions last to cover all previous deletions.
+        self.api.delete_all_revisions()
 
     @staticmethod
     def get_random_id() -> str:

--- a/test/setup_joplin.py
+++ b/test/setup_joplin.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import shutil
 import stat
 import subprocess
 import time
@@ -130,10 +131,12 @@ class JoplinServer:
             return
 
         # TODO: check if docker is installed and available
+        if shutil.which("docker") is None:
+            raise Exception("Please install docker and try again.")
         self.joplin_process = subprocess.Popen(
             ["docker", "run", "-p", "22300:22300", "joplin/server:latest"],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+            # stdout=subprocess.DEVNULL,
+            # stderr=subprocess.DEVNULL,
         )
 
         wait_for(api_available, timeout=20)

--- a/test/setup_joplin.py
+++ b/test/setup_joplin.py
@@ -130,13 +130,13 @@ class JoplinServer:
             self.joplin_process = None
             return
 
-        # TODO: check if docker is installed and available
         if shutil.which("docker") is None:
             raise Exception("Please install docker and try again.")
+        # TODO: Is caching the container in GHA possible?
         self.joplin_process = subprocess.Popen(
             ["docker", "run", "-p", "22300:22300", "joplin/server:latest"],
-            # stdout=subprocess.DEVNULL,
-            # stderr=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
         )
 
         wait_for(api_available, timeout=600)

--- a/test/setup_joplin.py
+++ b/test/setup_joplin.py
@@ -11,7 +11,7 @@ import requests
 from xvfbwrapper import Xvfb
 
 
-def download_joplin(destination: str) -> None:
+def download_joplin_client(destination: str) -> None:
     """Download the latest joplin desktop app release if not already done."""
     if not os.path.exists(destination):
         # obtain the version string
@@ -66,8 +66,8 @@ def wait_for(func: Callable[..., Any], interval: float = 0.5, timeout: int = 5) 
     raise TimeoutError(f"Function didn't return a valid value {result}.")
 
 
-class JoplinApp:
-    """Represents a joplin application."""
+class JoplinClient:
+    """Represents a joplin client application."""
 
     def __init__(self, app_path: str, profile: str):
         self.xvfb = xvfb = Xvfb()
@@ -108,3 +108,38 @@ class JoplinApp:
         self.xvfb.stop()
         self.joplin_process.terminate()
         self.joplin_process.wait()
+
+
+class JoplinServer:
+    """Represents a joplin server."""
+
+    def __init__(self) -> None:
+        # Wait until the API is available.
+        def api_available() -> Optional[bool]:
+            try:
+                response = requests.get("http://localhost:22300/api/ping", timeout=5)
+                if response.status_code == 200:
+                    return True
+            except Exception:
+                pass
+            return None
+
+        # check if server is running already
+        if api_available() is not None:
+            self.joplin_process = None
+            return
+
+        # TODO: check if docker is installed and available
+        self.joplin_process = subprocess.Popen(
+            ["docker", "run", "-p", "22300:22300", "joplin/server:latest"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+        wait_for(api_available, timeout=20)
+
+    def stop(self) -> None:
+        """Stop the joplin server."""
+        if self.joplin_process is not None:
+            self.joplin_process.terminate()
+            self.joplin_process.wait()

--- a/test/setup_joplin.py
+++ b/test/setup_joplin.py
@@ -139,7 +139,7 @@ class JoplinServer:
             # stderr=subprocess.DEVNULL,
         )
 
-        wait_for(api_available, timeout=20)
+        wait_for(api_available, timeout=600)
 
     def stop(self) -> None:
         """Stop the joplin server."""

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -16,7 +16,7 @@ import requests
 import urllib3
 
 from joppy import tools
-from joppy.api import Api
+from joppy.client_api import ClientApi
 import joppy.data_types as dt
 from . import setup_joplin
 
@@ -73,7 +73,7 @@ class TestBase(unittest.TestCase):
 
         LOGGER.debug("Test: %s", self.id())
 
-        self.api = Api(token=API_TOKEN)
+        self.api = ClientApi(token=API_TOKEN)
         # Notes get deleted automatically.
         self.api.delete_all_notebooks()
         self.api.delete_all_resources()

--- a/test/test_server_api.py
+++ b/test/test_server_api.py
@@ -2,7 +2,7 @@
 
 from typing import cast
 
-from joppy.server_api import ServerApi
+from joppy.server_api import deserialize, ServerApi
 import joppy.data_types as dt
 from . import common, setup_joplin
 
@@ -313,3 +313,35 @@ class Tag(ServerBase):
         for _ in range(count):
             self.api.add_tag()
         self.assertEqual(len(self.api.get_all_tags()), count)
+
+
+class Deserialize(ServerBase):
+    def test_note_only_metadata(self):
+        body = "id: 0e8d296dbef34588b0de060630ad2582\ntype_: 1"
+        result = deserialize(body)
+
+        self.assertIsInstance(result, dt.NoteData)
+        self.assertEqual(result.id, "0e8d296dbef34588b0de060630ad2582")
+        self.assertIsNone(result.title)
+        self.assertIsNone(result.body)
+
+    def test_note_title_metadata(self):
+        body = "note2\n\nid: 0e8d296dbef34588b0de060630ad2582\ntype_: 1"
+        result = deserialize(body)
+
+        self.assertIsInstance(result, dt.NoteData)
+        self.assertEqual(result.id, "0e8d296dbef34588b0de060630ad2582")
+        self.assertEqual(result.title, "note2")
+        self.assertIsNone(result.body)
+
+    def test_note_title_body_metadata(self):
+        body = (
+            "note2\n\nbody\n\nwith some\n\nnewlines\n\n"
+            "id: 0e8d296dbef34588b0de060630ad2582\ntype_: 1"
+        )
+        result = deserialize(body)
+
+        self.assertIsInstance(result, dt.NoteData)
+        self.assertEqual(result.id, "0e8d296dbef34588b0de060630ad2582")
+        self.assertEqual(result.title, "note2")
+        self.assertEqual(result.body, "body\n\nwith some\n\nnewlines")

--- a/test/test_server_api.py
+++ b/test/test_server_api.py
@@ -1,7 +1,5 @@
 """Tests for the Joplin server python API."""
 
-import threading
-import time
 from typing import cast
 
 from joppy.server_api import deserialize, ServerApi
@@ -331,7 +329,8 @@ class Deserialize(ServerBase):
         body = "id: 0e8d296dbef34588b0de060630ad2582\ntype_: 1"
         result = deserialize(body)
 
-        self.assertIsInstance(result, dt.NoteData)
+        # TODO: use assertIsInstance() when mypy understands it
+        assert isinstance(result, dt.NoteData)
         self.assertEqual(result.id, "0e8d296dbef34588b0de060630ad2582")
         self.assertIsNone(result.title)
         self.assertIsNone(result.body)
@@ -340,7 +339,8 @@ class Deserialize(ServerBase):
         body = "note2\n\nid: 0e8d296dbef34588b0de060630ad2582\ntype_: 1"
         result = deserialize(body)
 
-        self.assertIsInstance(result, dt.NoteData)
+        # TODO: use assertIsInstance() when mypy understands it
+        assert isinstance(result, dt.NoteData)
         self.assertEqual(result.id, "0e8d296dbef34588b0de060630ad2582")
         self.assertEqual(result.title, "note2")
         self.assertIsNone(result.body)
@@ -352,7 +352,8 @@ class Deserialize(ServerBase):
         )
         result = deserialize(body)
 
-        self.assertIsInstance(result, dt.NoteData)
+        # TODO: use assertIsInstance() when mypy understands it
+        assert isinstance(result, dt.NoteData)
         self.assertEqual(result.id, "0e8d296dbef34588b0de060630ad2582")
         self.assertEqual(result.title, "note2")
         self.assertEqual(result.body, "body\n\nwith some\n\nnewlines")

--- a/test/test_server_api.py
+++ b/test/test_server_api.py
@@ -29,7 +29,8 @@ def tearDownModule():  # pylint: disable=invalid-name
 class ServerBase(common.Base):
     def setUp(self):
         self.api = cast(ServerApi, API)
-        super().setUp()
+        with self.api.sync_lock():  # needed for clearing all data
+            super().setUp()
 
         self.api._acquire_sync_lock()
         if self.api.current_sync_lock is None:

--- a/test/test_server_api.py
+++ b/test/test_server_api.py
@@ -62,8 +62,8 @@ class Note(ServerBase):
 
     def test_delete(self):
         """Add and then delete a note."""
-        self.api.add_notebook()
-        id_ = self.api.add_note()
+        parent_id = self.api.add_notebook()
+        id_ = self.api.add_note(parent_id)
         notes = self.api.get_notes()
         self.assertEqual(len(notes.items), 1)
 
@@ -87,10 +87,10 @@ class Note(ServerBase):
 
     def test_get_all_notes(self):
         """Get all notes, unpaginated."""
-        self.api.add_notebook()
+        parent_id = self.api.add_notebook()
         count = 20
         for _ in range(count):
-            self.api.add_note()
+            self.api.add_note(parent_id)
         self.assertEqual(len(self.api.get_all_notes()), count)
 
     def test_move(self):
@@ -309,8 +309,8 @@ class Tag(ServerBase):
 
     def test_add_to_note(self):
         """Add a tag to an existing note."""
-        self.api.add_notebook()
-        note_id = self.api.add_note()
+        parent_id = self.api.add_notebook()
+        note_id = self.api.add_note(parent_id)
         tag_id = self.api.add_tag()
         self.api.add_tag_to_note(tag_id=tag_id, note_id=note_id)
 
@@ -323,8 +323,8 @@ class Tag(ServerBase):
 
     def test_add_with_parent(self):
         """Add a tag as child for an existing note."""
-        self.api.add_notebook()
-        parent_id = self.api.add_note()
+        notebook_id = self.api.add_notebook()
+        parent_id = self.api.add_note(notebook_id)
         id_ = self.api.add_tag(parent_id=parent_id)
 
         tags = self.api.get_tags().items
@@ -347,7 +347,6 @@ class Tag(ServerBase):
 
     def test_get_all_tags(self):
         """Get all tags, unpaginated."""
-        # Small limit and count to create/remove as less as possible items.
         count = 20
         for _ in range(count):
             self.api.add_tag()

--- a/test/test_server_api.py
+++ b/test/test_server_api.py
@@ -98,7 +98,7 @@ class Note(ServerBase):
     def test_get_all_notes(self):
         """Get all notes, unpaginated."""
         parent_id = self.api.add_notebook()
-        count = 20
+        count = 101  # pagination seems to start at 100 items
         for _ in range(count):
             self.api.add_note(parent_id)
         self.assertEqual(len(self.api.get_all_notes()), count)
@@ -150,7 +150,7 @@ class Notebook(ServerBase):
 
     def test_get_all_notebooks(self):
         """Get all notebooks, unpaginated."""
-        count = 20
+        count = 101
         for _ in range(count):
             self.api.add_notebook()
         self.assertEqual(len(self.api.get_all_notebooks()), count)
@@ -319,7 +319,7 @@ class Tag(ServerBase):
 
     def test_get_all_tags(self):
         """Get all tags, unpaginated."""
-        count = 20
+        count = 101
         for _ in range(count):
             self.api.add_tag()
         self.assertEqual(len(self.api.get_all_tags()), count)

--- a/test/test_server_api.py
+++ b/test/test_server_api.py
@@ -1,5 +1,7 @@
 """Tests for the Joplin server python API."""
 
+import threading
+import time
 from typing import cast
 
 from joppy.server_api import deserialize, ServerApi
@@ -313,6 +315,15 @@ class Tag(ServerBase):
         for _ in range(count):
             self.api.add_tag()
         self.assertEqual(len(self.api.get_all_tags()), count)
+
+
+class User(ServerBase):
+    def test_get_current_user(self):
+        """The current user should be available and have read and write permissions."""
+        current_user = self.api.get_current_user()
+        self.assertIsNotNone(current_user)
+        self.assertTrue(current_user.enabled)
+        self.assertTrue(current_user.can_upload)
 
 
 class Deserialize(ServerBase):

--- a/test/test_server_api.py
+++ b/test/test_server_api.py
@@ -1,5 +1,6 @@
 """Tests for the Joplin server python API."""
 
+import string
 import time
 from typing import cast
 import unittest
@@ -51,25 +52,6 @@ class Note(ServerBase):
         self.assertEqual(len(notes), 1)
         self.assertEqual(notes[0].id, id_)
         self.assertEqual(notes[0].parent_id, parent_id)
-
-    # TODO
-    # def test_add_attach_image(self):
-    #     """Add a note with an image attached."""
-    #     self.api.add_notebook()
-    #     image_data = tools.encode_base64("test/grant_authorization_button.png")
-    #     note_id = self.api.add_note(
-    #         image_data_url=f"data:image/png;base64,{image_data}"
-    #     )
-
-    #     # Check that there is a resource.
-    #     resources = self.api.get_resources().items
-    #     self.assertEqual(len(resources), 1)
-    #     resource_id = resources[0].id
-
-    #     # Verify the resource is attached to the note.
-    #     resources = self.api.get_resources(note_id=note_id).items
-    #     self.assertEqual(len(resources), 1)
-    #     self.assertEqual(resources[0].id, resource_id)
 
     def test_delete(self):
         """Add and then delete a note."""
@@ -252,20 +234,20 @@ class Resource(ServerBase):
             self.api.add_resource(filename=filename)
         self.assertEqual(len(self.api.get_all_resources()), count)
 
-    # TODO
-    #     @common.with_resource
-    #     def test_modify_title(self, filename):
-    #         """Modify a resource title."""
-    #         id_ = self.api.add_resource(filename=filename)
+    # @common.with_resource
+    # def test_modify_title(self, filename):
+    #     """Modify a resource title."""
+    #     id_ = self.api.add_resource(filename=filename)
 
-    #         new_title = self.get_random_string()
-    #         self.api.modify_resource(id_=id_, title=new_title)
-    #         self.assertEqual(self.api.get_resource(id_=id_).title, new_title)
+    #     new_title = self.get_random_string(exclude=string.whitespace)
+    #     self.api.modify_resource(id_=id_, title=new_title)
+    #     self.assertEqual(self.api.get_resource(id_=id_).title, new_title)
 
     @common.with_resource
     def test_check_property_title(self, filename):
         """Check the title of a resource."""
-        title = self.get_random_string()
+        # newline seems to be stripped from the title
+        title = self.get_random_string(exclude=string.whitespace)
         id_ = self.api.add_resource(filename=filename, title=title)
         resource = self.api.get_resource(id_=id_)
         self.assertEqual(resource.title, title)
@@ -287,10 +269,6 @@ class Tag(ServerBase):
         tag_id = self.api.add_tag()
         self.api.add_tag_to_note(tag_id=tag_id, note_id=note_id)
 
-        # TODO: get_note_tag()
-        # notes = self.api.get_notes(tag_id=tag_id).items
-        # self.assertEqual(len(notes), 1)
-        # self.assertEqual(notes[0].id, note_id)
         tags = self.api.get_all_tags()
         self.assertEqual(len(tags), 1)
 

--- a/test/test_server_api.py
+++ b/test/test_server_api.py
@@ -1,0 +1,354 @@
+"""Tests for the Joplin server python API."""
+
+from typing import cast
+
+from joppy.server_api import ServerApi
+import joppy.data_types as dt
+from . import common, setup_joplin
+
+
+API = None
+SERVER = None
+
+
+def setUpModule():  # pylint: disable=invalid-name
+    global API, SERVER
+    SERVER = setup_joplin.JoplinServer()
+    # login only once to prevent
+    # "429 Client Error: Too Many Requests for url: http://localhost:22300/login"
+    API = ServerApi()
+
+
+def tearDownModule():  # pylint: disable=invalid-name
+    if SERVER is not None:
+        SERVER.stop()
+
+
+class ServerBase(common.Base):
+    def setUp(self):
+        self.api = cast(ServerApi, API)
+        super().setUp()
+
+
+class Note(ServerBase):
+    def test_add(self):
+        """Add a note to an existing notebook."""
+        parent_id = self.api.add_notebook()
+        id_ = self.api.add_note(parent_id=parent_id)
+
+        notes = self.api.get_notes().items
+        self.assertEqual(len(notes), 1)
+        self.assertEqual(notes[0].id, id_)
+        self.assertEqual(notes[0].parent_id, parent_id)
+
+    # TODO
+    # def test_add_attach_image(self):
+    #     """Add a note with an image attached."""
+    #     self.api.add_notebook()
+    #     image_data = tools.encode_base64("test/grant_authorization_button.png")
+    #     note_id = self.api.add_note(
+    #         image_data_url=f"data:image/png;base64,{image_data}"
+    #     )
+
+    #     # Check that there is a resource.
+    #     resources = self.api.get_resources().items
+    #     self.assertEqual(len(resources), 1)
+    #     resource_id = resources[0].id
+
+    #     # Verify the resource is attached to the note.
+    #     resources = self.api.get_resources(note_id=note_id).items
+    #     self.assertEqual(len(resources), 1)
+    #     self.assertEqual(resources[0].id, resource_id)
+
+    def test_delete(self):
+        """Add and then delete a note."""
+        self.api.add_notebook()
+        id_ = self.api.add_note()
+        notes = self.api.get_notes()
+        self.assertEqual(len(notes.items), 1)
+
+        self.api.delete_note(id_=id_)
+        self.assertEqual(self.api.get_notes().items, [])
+
+    def test_get_note(self):
+        """Get a specific note."""
+        parent_id = self.api.add_notebook()
+        id_ = self.api.add_note(parent_id=parent_id)
+        note = self.api.get_note(id_=id_)
+        self.assertEqual(note.type_, dt.ItemType.NOTE)
+
+    def test_get_notes(self):
+        """Get all notes."""
+        parent_id = self.api.add_notebook()
+        self.api.add_note(parent_id=parent_id)
+        notes = self.api.get_notes()
+        self.assertEqual(len(notes.items), 1)
+        self.assertFalse(notes.has_more)
+
+    def test_get_all_notes(self):
+        """Get all notes, unpaginated."""
+        self.api.add_notebook()
+        count = 20
+        for _ in range(count):
+            self.api.add_note()
+        self.assertEqual(len(self.api.get_all_notes()), count)
+
+    def test_move(self):
+        """Move a note from one notebook to another."""
+        original_title = "test title"
+        original_body = "test body"
+
+        notebook_1_id = self.api.add_notebook()
+        notebook_2_id = self.api.add_notebook()
+        id_ = self.api.add_note(
+            parent_id=notebook_1_id, title=original_title, body=original_body
+        )
+
+        note = self.api.get_note(id_=id_)
+        self.assertEqual(note.parent_id, notebook_1_id)
+
+        self.api.modify_note(id_=id_, parent_id=notebook_2_id)
+        note = self.api.get_note(id_=id_)
+        self.assertEqual(note.parent_id, notebook_2_id)
+
+        # Ensure the original properties aren't modified.
+        self.assertEqual(note.body, original_body)
+        self.assertEqual(note.title, original_title)
+
+
+class Notebook(ServerBase):
+    def test_add(self):
+        """Add a notebook."""
+        id_ = self.api.add_notebook()
+
+        notebooks = self.api.get_notebooks().items
+        self.assertEqual(len(notebooks), 1)
+        self.assertEqual(notebooks[0].id, id_)
+
+    def test_get_notebook(self):
+        """Get a specific notebook."""
+        id_ = self.api.add_notebook()
+        notebook = self.api.get_notebook(id_=id_)
+        self.assertEqual(notebook.type_, dt.ItemType.FOLDER)
+
+    def test_get_notebooks(self):
+        """Get all notebooks."""
+        self.api.add_notebook()
+        notebooks = self.api.get_notebooks()
+        self.assertEqual(len(notebooks.items), 1)
+        self.assertFalse(notebooks.has_more)
+
+    def test_get_all_notebooks(self):
+        """Get all notebooks, unpaginated."""
+        count = 20
+        for _ in range(count):
+            self.api.add_notebook()
+        self.assertEqual(len(self.api.get_all_notebooks()), count)
+
+    def test_move(self):
+        """Move a root notebok to another notebook. It's now a subnotebook."""
+        first_id = self.api.add_notebook()
+        second_id = self.api.add_notebook()
+        self.assertEqual(self.api.get_notebook(id_=first_id).parent_id, None)
+        self.assertEqual(self.api.get_notebook(id_=second_id).parent_id, None)
+
+        self.api.modify_notebook(id_=first_id, parent_id=second_id)
+        self.assertEqual(self.api.get_notebook(id_=first_id).parent_id, second_id)
+        self.assertEqual(self.api.get_notebook(id_=second_id).parent_id, None)
+
+
+class Ping(ServerBase):
+    def test_ping(self):
+        """Ping should return the test string."""
+        ping = self.api.ping()
+        self.assertEqual(
+            ping.json(), {"status": "ok", "message": "Joplin Server is running"}
+        )
+
+
+# TODO
+# class Resource(ServerBase):
+#     @with_resource
+#     def test_add(self, filename):
+#         """Add a resource."""
+#         id_ = self.api.add_resource(filename=filename)
+
+#         resources = self.api.get_resources().items
+#         self.assertEqual(len(resources), 1)
+#         self.assertEqual(resources[0].id, id_)
+
+#     @with_resource
+#     def test_add_to_note(self, filename):
+#         """Add a resource to an existing note."""
+#         self.api.add_notebook()
+#         for file_ in ["test/grant_authorization_button.png", filename]:
+#             with self.subTest(file_=file_):
+#                 note_id = self.api.add_note()
+#                 resource_id = self.api.add_resource(filename=file_)
+#                 self.api.add_resource_to_note(resource_id=resource_id,
+# note_id=note_id)
+
+#                 # Verify the resource is attached to the note.
+#                 resources = self.api.get_resources(
+#                     note_id=note_id, fields="id,mime"
+#                 ).items
+#                 self.assertEqual(len(resources), 1)
+#                 self.assertEqual(resources[0].id, resource_id)
+
+#                 # Verify the markdown is correct (prefix "!" for images).
+#                 note = self.api.get_note(id_=note_id, fields="body")
+#                 # TODO: Use "assertIsNotNone()" when
+#                 # https://github.com/python/mypy/issues/5528 is resolved.
+#                 assert resources[0].mime is not None
+#                 image_prefix = "!" if resources[0].mime.startswith("image/") else ""
+#                 self.assertEqual(
+#                     f"\n{image_prefix}[{file_}](:/{resource_id})", note.body
+#                 )
+
+#     @with_resource
+#     def test_delete(self, filename):
+#         """Add and then delete a resource."""
+#         id_ = self.api.add_resource(filename=filename)
+#         resources = self.api.get_resources()
+#         self.assertEqual(len(resources.items), 1)
+
+#         self.api.delete_resource(id_=id_)
+#         self.assertEqual(self.api.get_resources().items, [])
+#         self.assertEqual(os.listdir(f"{PROFILE}/resources"), [])
+
+#     @with_resource
+#     def test_get_resource(self, filename):
+#         """Get metadata about a specific resource."""
+#         id_ = self.api.add_resource(filename=filename)
+#         resource = self.api.get_resource(id_=id_)
+#         self.assertEqual(resource.assigned_fields(), resource.default_fields())
+#         self.assertEqual(resource.type_, dt.ItemType.RESOURCE)
+
+#     @with_resource
+#     def test_get_resource_file(self, filename):
+#         """Get a specific resource in binary format."""
+#         for file_ in ("test/grant_authorization_button.png", filename):
+#             id_ = self.api.add_resource(filename=file_)
+#             resource = self.api.get_resource_file(id_=id_)
+#             with open(file_, "rb") as resource_file:
+#                 self.assertEqual(resource, resource_file.read())
+
+#     @with_resource
+#     def test_get_resources(self, filename):
+#         """Get all resources."""
+#         self.api.add_resource(filename=filename)
+#         resources = self.api.get_resources()
+#         self.assertEqual(len(resources.items), 1)
+#         self.assertFalse(resources.has_more)
+#         for resource in resources.items:
+#             self.assertEqual(resource.assigned_fields(), resource.default_fields())
+
+#     @with_resource
+#     def test_get_all_resources(self, filename):
+#         """Get all resources, unpaginated."""
+#         # Small limit and count to create/remove as less as possible items.
+#         count, limit = random.randint(1, 10), random.randint(1, 10)
+#         for _ in range(count):
+#             self.api.add_resource(filename=filename)
+#         self.assertEqual(
+#             len(self.api.get_resources(limit=limit).items), min(limit, count)
+#         )
+#         self.assertEqual(len(self.api.get_all_resources(limit=limit)), count)
+
+#     @with_resource
+#     def test_get_resources_valid_properties(self, filename):
+#         """Try to get specific properties of a resource."""
+#         self.api.add_resource(filename=filename)
+#         property_combinations = self.get_combinations(dt.ResourceData.fields())
+#         for properties in property_combinations:
+#             resources = self.api.get_resources(fields=",".join(properties))
+#             for resource in resources.items:
+#                 self.assertEqual(resource.assigned_fields(), set(properties))
+
+#     @with_resource
+#     def test_modify_title(self, filename):
+#         """Modify a resource title."""
+#         id_ = self.api.add_resource(filename=filename)
+
+#         new_title = self.get_random_string()
+#         self.api.modify_resource(id_=id_, title=new_title)
+#         self.assertEqual(self.api.get_resource(id_=id_).title, new_title)
+
+#     @with_resource
+#     def test_check_derived_properties(self, filename):
+#         """Check the derived properties. I. e. mime type, extension and size."""
+#         for file_ in ["test/grant_authorization_button.png", filename]:
+#             id_ = self.api.add_resource(filename=file_)
+#             resource = self.api.get_resource(id_=id_,
+# fields="mime,file_extension,size")
+#             mime_type, _ = mimetypes.guess_type(file_)
+#             self.assertEqual(
+#                 resource.mime,
+#                 mime_type if mime_type is not None else "application/octet-stream",
+#             )
+#             self.assertEqual(resource.file_extension, os.path.splitext(file_)[1][1:])
+#             self.assertEqual(resource.size, os.path.getsize(file_))
+
+#     @with_resource
+#     def test_check_property_title(self, filename):
+#         """Check the title of a resource."""
+#         title = self.get_random_string()
+#         id_ = self.api.add_resource(filename=filename, title=title)
+#         resource = self.api.get_resource(id_=id_)
+#         self.assertEqual(resource.title, title)
+
+
+class Tag(ServerBase):
+    def test_add_no_note(self):
+        """Tags can be added even without notes."""
+        id_ = self.api.add_tag()
+
+        tags = self.api.get_tags().items
+        self.assertEqual(len(tags), 1)
+        self.assertEqual(tags[0].id, id_)
+
+    def test_add_to_note(self):
+        """Add a tag to an existing note."""
+        self.api.add_notebook()
+        note_id = self.api.add_note()
+        tag_id = self.api.add_tag()
+        self.api.add_tag_to_note(tag_id=tag_id, note_id=note_id)
+
+        # TODO: get_note_tag()
+        # notes = self.api.get_notes(tag_id=tag_id).items
+        # self.assertEqual(len(notes), 1)
+        # self.assertEqual(notes[0].id, note_id)
+        tags = self.api.get_all_tags()
+        self.assertEqual(len(tags), 1)
+
+    def test_add_with_parent(self):
+        """Add a tag as child for an existing note."""
+        self.api.add_notebook()
+        parent_id = self.api.add_note()
+        id_ = self.api.add_tag(parent_id=parent_id)
+
+        tags = self.api.get_tags().items
+        self.assertEqual(len(tags), 1)
+        self.assertEqual(tags[0].id, id_)
+        self.assertEqual(tags[0].parent_id, parent_id)
+
+    def test_get_tag(self):
+        """Get a specific tag."""
+        id_ = self.api.add_tag()
+        tag = self.api.get_tag(id_=id_)
+        self.assertEqual(tag.type_, dt.ItemType.TAG)
+
+    def test_get_tags(self):
+        """Get all tags."""
+        self.api.add_tag()
+        tags = self.api.get_tags()
+        self.assertEqual(len(tags.items), 1)
+        self.assertFalse(tags.has_more)
+
+    def test_get_all_tags(self):
+        """Get all tags, unpaginated."""
+        # Small limit and count to create/remove as less as possible items.
+        count = 20
+        for _ in range(count):
+            self.api.add_tag()
+        self.assertEqual(len(self.api.get_all_tags()), count)


### PR DESCRIPTION
- [x] [items](https://github.com/laurent22/joplin/blob/b617a846964ea49be2ffefd31439e911ad84ed8c/packages/server/src/routes/api/items.ts#L95)
  - [x] Basic items, like notes/notebooks/tags -> Implemented in a similar way like the client API.
  - [x] Resources
  - [x] [api/items/:id/delta](https://github.com/laurent22/joplin/blob/b617a846964ea49be2ffefd31439e911ad84ed8c/packages/server/src/routes/api/items.ts#L136) -> Not implemented. Not sure if needed for automation.
  - [x] [api/items/:id/children](https://github.com/laurent22/joplin/blob/b617a846964ea49be2ffefd31439e911ad84ed8c/packages/server/src/routes/api/items.ts#L141) -> Not sure how it works. Skipped for now.
- [x] [batch](https://github.com/laurent22/joplin/blob/b617a846964ea49be2ffefd31439e911ad84ed8c/packages/server/src/routes/api/batch.ts#L72) / [batch items](https://github.com/laurent22/joplin/blob/b617a846964ea49be2ffefd31439e911ad84ed8c/packages/server/src/routes/api/batch_items.ts#L10) -> Not implemented. Single access is sufficient for now -> https://github.com/marph91/joppy/issues/28
- [x] [api/events](https://github.com/laurent22/joplin/blob/b617a846964ea49be2ffefd31439e911ad84ed8c/packages/server/src/routes/api/events.ts) -> Not implemented. Seems to be used to trigger a sync event.
- [x] [debug](https://github.com/laurent22/joplin/blob/b617a846964ea49be2ffefd31439e911ad84ed8c/packages/server/src/routes/api/debug.ts#L22) -> Not implemented. [Only available in dev env.](https://github.com/laurent22/joplin/blob/b617a846964ea49be2ffefd31439e911ad84ed8c/packages/server/src/routes/api/debug.ts#L23) 
- [x] [locks](https://github.com/laurent22/joplin/blob/b617a846964ea49be2ffefd31439e911ad84ed8c/packages/server/src/routes/api/locks.ts) -> https://github.com/marph91/joppy/pull/27/commits/b0a7cd105716eec9ad3dd884feb8a189e30950e9
- [x] [sessions](https://github.com/laurent22/joplin/blob/b617a846964ea49be2ffefd31439e911ad84ed8c/packages/server/src/routes/api/sessions.ts#L14) -> Not implemented. Not sure if needed for automation.
- [x] [share users](https://github.com/laurent22/joplin/blob/b617a846964ea49be2ffefd31439e911ad84ed8c/packages/server/src/routes/api/share_users.ts) -> Not implemented. Not sure if needed for automation.
- [x] [shares](https://github.com/laurent22/joplin/blob/b617a846964ea49be2ffefd31439e911ad84ed8c/packages/server/src/routes/api/shares.ts#L20) -> Not implemented. Not sure if needed for automation.
- [x] [users](https://github.com/laurent22/joplin/blob/b617a846964ea49be2ffefd31439e911ad84ed8c/packages/server/src/routes/api/users.ts#L24) -> Partially implemented. Only a function to fetch users and their permissions.
- [x] encryption -> Not implemented. Too complex. Too much potential for error.
- [x] parse info.json (GET /api/items/root:/info.json:/content)