### PR TITLE
Fix: Redact API token from debug logs

### DIFF
--- a/joppy/client_api.py
+++ b/joppy/client_api.py
@@ -52,8 +52,9 @@ class ApiBase:
         data: Optional[dt.JoplinKwargs] = None,
         files: Optional[Dict[str, Any]] = None,
     ) -> requests.models.Response:
+        log_query = {k: ('***REDACTED***' if k == 'token' else v) for k, v in query.items()}
         LOGGER.debug(
-            f"API: {method} request: path={path}, query={query}, data={data}, "
+            f"API: {method} request: path={path}, query={log_query}, data={data}, "
             f"files={files}"
         )
         if data is not None and "id_" in data:


### PR DESCRIPTION
Addresses a security issue where the Joplin API token could be exposed in application logs when debug logging is enabled.

In `joppy/client_api.py`, the `_request` method logs the full query parameters at DEBUG level:

```python
LOGGER.debug(f"API: {method} request: path={path}, query={query}...")
```

Since the API token is included in the query parameters (`query["token"] = self.token`), enabling debug logging causes the token to be written to logs in plaintext. 

Solution is pretty straightforward - Redact the token value before logging. This preserves the debugging while protecting the token.
